### PR TITLE
Add Dockerfile for fast server startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+tests
+.env
+Dockerfile
+Dockerfile.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use slim image for smaller size
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Disable writing .pyc files and enable stdout flushing
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install Python dependencies first for better cache utilization
+COPY pyproject.toml README.md ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir mcp>=1.3.0 fastapi Cinemagoer
+
+# Copy application code
+COPY src ./src
+COPY script ./script
+
+# Install the package
+RUN pip install --no-cache-dir .
+
+# Expose default HTTP port
+EXPOSE 8000
+
+# Run the server using HTTP transport for quick startup
+ENV MCP_TRANSPORT=HTTP \
+    PORT=8000
+
+CMD ["mcp-imdb"]


### PR DESCRIPTION
## Summary
- add `Dockerfile` using Python 3.11 slim image and HTTP transport
- add `.dockerignore` to speed up Docker build

## Testing
- `pip install -e .`
- `pip install fastapi Cinemagoer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684607654dd4832d8dd4ee538794a52e