### PR TITLE
Switch server to fastmcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Install Python dependencies first for better cache utilization
 COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir mcp>=1.3.0 fastapi Cinemagoer
+    && pip install --no-cache-dir fastmcp fastapi Cinemagoer
 
 # Copy application code
 COPY src ./src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A Model Context Protocol (MCP) server for accessing IMDB data"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = [ "mcp>=1.3.0",]
+dependencies = [ "fastmcp>=2.7.1",]
 [[project.authors]]
 name = "Cheng-Lung Sung"
 email = "clsung@gmail.com"

--- a/script/test_mcp-imdb.py
+++ b/script/test_mcp-imdb.py
@@ -1,17 +1,16 @@
 import asyncio
-import os
 import logging
 import signal
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+from fastmcp.client.client import ClientSession
+from fastmcp.client.transports import StdioTransport
 
 # Constants
 TOOL_TIMEOUT = 30.0  # seconds
 
-server_params = StdioServerParameters(
-    command="uv", # Executable
-    args=["run", "mcp-imdb"], # Optional command line arguments
-    env=None # Optional environment variables
+transport = StdioTransport(
+    command="uv",
+    args=["run", "mcp-imdb"],
+    env=None,
 )
 
 # Set up logging
@@ -29,8 +28,7 @@ async def run():
     logger.info("Starting MCP client test")
     
     # Start the MCP client
-    async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
+    async with transport.connect_session() as session:
 
             # Initialize the connection
             await session.initialize()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,16 +1,12 @@
 import pytest
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+from fastmcp.client.client import ClientSession
+from fastmcp.client.transports import StdioTransport
 
 @pytest.mark.asyncio
 async def test_server_integration():
-    server_params = StdioServerParameters(
-        command="uv",
-        args=["run", "mcp-imdb"]
-    )
-    
-    async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
+    transport = StdioTransport(command="uv", args=["run", "mcp-imdb"])
+
+    async with transport.connect_session() as session:
             # Test initialization
             await session.initialize()
             


### PR DESCRIPTION
## Summary
- depend on `fastmcp` instead of `mcp`
- use `FastMCP` server and simplified `main`
- update helper script and integration test to rely on `StdioTransport`
- update Dockerfile to install `fastmcp`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp_imdb')*

------
https://chatgpt.com/codex/tasks/task_e_684611ae63fc832d9058295a58efc9a2